### PR TITLE
Used f-string to format the string used as an argument in os.path.join

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ BASE_PATH = os.path.dirname(__file__)
 
 
 def get_requirements(suffix=''):
-    with open(os.path.join(BASE_PATH, 'requirements%s.txt' % suffix)) as f:
+    with open(os.path.join(BASE_PATH, f'requirements{suffix}.txt')) as f:
         rv = f.read().splitlines()
     return rv
 


### PR DESCRIPTION
A little change made to the string formatting

It will achieve the exact result as %-formatting, but f-string is commonly used recently.
It also has performance advantage to %-formatting. See -> https://realpython.com/python-f-strings/
supported in Python 3.6+